### PR TITLE
Fix batch re-sending failing after the 2nd item

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -127,6 +127,7 @@ function transform(data: AlertData): { version: string, empty: boolean, msgtype:
 app.use(express.json())
 
 app.post("/webhook/:id", async (req: Request, res: Response) => {
+    var success = true;
     try {
         logger.info(`Received data from the alertmanager for the id: ${req.params.id}`);
         var transforedData = transform(req.body as AlertData);
@@ -141,13 +142,16 @@ app.post("/webhook/:id", async (req: Request, res: Response) => {
             );
             if (!response.ok) {
                 logger.error(`Failed to forward the data to the upstream service: ${response.text()}`);
-                res.status(500).send("Failed to forward the data to the upstream service");
-            } else {
-                res.status(200).send("Data forwarded successfully");
+                success = false;
             }
         }
     } catch (error) {
         logger.error(`Failed to forward the data to the upstream service: ${error}`);
+        success = false;
+    }
+    if (success) {
+        res.status(200).send("Data forwarded successfully");
+    } else {
         res.status(500).send("Failed to forward the data to the upstream service");
     }
 });


### PR DESCRIPTION
An HTTP response was being sent after every item being processed, causing the re-sending to break after the 2nd item due to a response having already been sent on the stream.

Regression from c2e571cdaee4679c684fb388166da5a2f163cba0

Tested: afnix.fr deployment used to never send more than 2 alerts of the same type, with this commit applied the issue disappears.